### PR TITLE
Add extra scopes option

### DIFF
--- a/cmd/oidc-reverse-proxy.go
+++ b/cmd/oidc-reverse-proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -62,6 +63,7 @@ func run(osSignals <-chan os.Signal) (int, string) {
 	cookiePath := flag.String("cookie-path", "", "")
 	cookieHTTPOnly := flag.Bool("cookie-http-only", true, "")
 	cookieSecure := flag.Bool("cookie-secure", true, "")
+	rawExtraScopes := flag.String("extra-scopes", "", "")
 
 	flag.Parse()
 
@@ -108,6 +110,10 @@ func run(osSignals <-chan os.Signal) (int, string) {
 	if *cookiePath == "" {
 		return xCLIUsage, "-cookie-path missing"
 	}
+	extraScopes := []string{}
+	if *rawExtraScopes != "" {
+		extraScopes = strings.Split(*rawExtraScopes, ",")
+	}
 
 	glog.Info("Initializing application")
 
@@ -126,6 +132,7 @@ func run(osSignals <-chan os.Signal) (int, string) {
 		AcceptUnverifiedEmails: !*requireVerifiedEmail,
 		Context:                context.Background(),
 		HTTPTransport:          newHTTPTransport(*tlsVerifyIssuer),
+		ExtraScopes:            extraScopes,
 	})
 	if err != nil {
 		return xGeneralError, err.Error()

--- a/pkg/auth/oidc/oidc.go
+++ b/pkg/auth/oidc/oidc.go
@@ -22,6 +22,7 @@ type FlowConfig struct {
 	AcceptUnverifiedEmails bool
 	Context                context.Context
 	HTTPTransport          *http.Transport
+	ExtraScopes            []string
 }
 type flow struct {
 	context                context.Context
@@ -43,6 +44,12 @@ func NewOpenIDConnectFlow(config *FlowConfig) (auth.Flow, error) {
 		return nil, errors.Wrapf(err, "failed to create OpenID Connect provider %s", config.IssuerURL)
 	}
 
+	scopes := []string{oidc.ScopeOpenID}
+
+	if config.ExtraScopes != nil {
+		scopes = append(scopes, config.ExtraScopes...)
+	}
+
 	// Configure an OpenID Connect aware OAuth2 client.
 	oauth2Config := oauth2.Config{
 		ClientID:     config.ClientID,
@@ -53,7 +60,7 @@ func NewOpenIDConnectFlow(config *FlowConfig) (auth.Flow, error) {
 		Endpoint: provider.Endpoint(),
 
 		// "openid" is a required scope for OpenID Connect flows.
-		Scopes: []string{oidc.ScopeOpenID},
+		Scopes: scopes,
 	}
 
 	verifier := provider.Verifier(&oidc.Config{ClientID: config.ClientID})


### PR DESCRIPTION
We're using `coreos/dex` as OIDC provider, and I needed to request extra scopes so RBAC would work.

I added a `-extra-scopes` option in which you can pass scopes separated by comma.

Example: `-extra-scopes=profile,email,groups`